### PR TITLE
PR‑001a — TypeScript type fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "ts-node": "^10",
     "jest": "^29",
     "@types/jest": "^29",
+    "@types/node": "^20",
+    "chalk": "^5",
     "ascii-histogram": "^1.1.0"
   }
 }

--- a/src/harmonic-harness.ts
+++ b/src/harmonic-harness.ts
@@ -1,5 +1,5 @@
 import { goldenRatio } from "../spirill-rii-toolchain/lex/constants";
-import histogram from "ascii-histogram";
+import histogram from "ascii-histogram"; // now typed via local declaration
 
 // Sieve-based prime resonance function
 function primeResonance(n: number): number {

--- a/src/types/ascii-histogram.d.ts
+++ b/src/types/ascii-histogram.d.ts
@@ -1,0 +1,8 @@
+declare module "ascii-histogram" {
+  interface HistogramOptions {
+    bar?: string;
+    width?: number;
+  }
+  function histogram(values: Record<string, number>, opts?: HistogramOptions): string;
+  export default histogram;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "NodeNext",
     "strict": true,
     "esModuleInterop": true,
+    "types": ["node"],
     "outDir": "build"
   },
   "include": ["src", "spirill-rii-toolchain"]


### PR DESCRIPTION
## Summary
- add Node.js typings and chalk to dev deps
- add histogram declaration
- update compiler options for node types
- document typed histogram import

## Testing
- `npx jest --selectProjects hv221` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_68596c939ccc83278a9de812614dd12d