### PR TITLE
Update ascii-histogram typings

### DIFF
--- a/src/types/ascii-histogram.d.ts
+++ b/src/types/ascii-histogram.d.ts
@@ -1,8 +1,11 @@
 declare module "ascii-histogram" {
-  interface HistogramOptions {
+  export interface HistogramOptions {
     bar?: string;
     width?: number;
   }
-  function histogram(values: Record<string, number>, opts?: HistogramOptions): string;
+  function histogram(
+    data: number[] | Record<string, number>,
+    options?: HistogramOptions
+  ): string;
   export default histogram;
 }


### PR DESCRIPTION
## Summary
- export HistogramOptions interface and allow array data for `ascii-histogram`

## Testing
- `pnpm hv221:test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596dd07f6883279db9da661f7afcde