### PR TITLE
Fix Jest runtime with ts-jest preset

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,11 @@
+/** @type {import('jest').Config} */
 module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
   projects: [
     {
       displayName: 'hv221',
-      testMatch: ['<rootDir>/src/__tests__/hv221.*.ts'],
-      transform: {
-        '^.+\\.ts$': ['ts-jest', { tsconfig: './tsconfig.json' }]
-      }
-    }
-  ]
+      testMatch: ['<rootDir>/src/__tests__/hv221.spec.ts'],
+    },
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "ts-node": "^10",
     "jest": "^29",
     "@types/jest": "^29",
+    "ts-jest": "^29",
     "@types/node": "^20",
     "chalk": "^5",
     "ascii-histogram": "^1.1.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "NodeNext",
     "strict": true,
     "esModuleInterop": true,
-    "types": ["node"],
+    "types": ["node", "jest"],
     "outDir": "build"
   },
   "include": ["src", "spirill-rii-toolchain"]


### PR DESCRIPTION
## Summary
- add `ts-jest` and configure Jest to use it
- add Jest types in tsconfig

## Testing
- `npm test --silent` *(fails: ENOTFOUND registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68596ea12da48327838db5b3be0be17b