### PR TITLE
Fix Jest config and HV221 label

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,11 @@
 /** @type {import('jest').Config} */
 module.exports = {
+  rootDir: '.',
   preset: 'ts-jest',
   testEnvironment: 'node',
-  projects: [
-    {
-      displayName: 'hv221',
-      testMatch: ['<rootDir>/src/__tests__/hv221.spec.ts'],
-    },
-  ],
+  modulePathIgnorePatterns: ['<rootDir>/spir1L-os.com'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }]
+  },
+  testMatch: ['<rootDir>/src/__tests__/**/*.spec.ts']
 };

--- a/src/__tests__/hv221.spec.ts
+++ b/src/__tests__/hv221.spec.ts
@@ -1,6 +1,6 @@
 import { runHarness } from "../harmonic-harness";
 
-describe('HV\u221221 Lyapunov harness', () => {
+describe('HV221 Lyapunov harness', () => {
   it('contracts for 2\u00a0000 steps', () => {
     expect(() => runHarness(2000)).not.toThrow();
   });


### PR DESCRIPTION
## Summary
- configure Jest with ts-jest preset and common transform rules
- update the HV221 test label to match harness output

## Testing
- `npm run hv221:test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596f7e7ce88327a46debecd7ea75b9