### PR TITLE
PR-001e— Jest ESM & duplicate-package fix

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,13 @@
 /** @type {import('jest').Config} */
 module.exports = {
-  rootDir: '.',
   preset: 'ts-jest',
   testEnvironment: 'node',
   modulePathIgnorePatterns: ['<rootDir>/spir1L-os.com'],
-  transform: {
-    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }]
-  },
-  testMatch: ['<rootDir>/src/__tests__/**/*.spec.ts']
+  projects: [
+    {
+      displayName: 'hv221',
+      testMatch: ['<rootDir>/src/__tests__/**/*.spec.ts'],
+      transform: { '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }] }
+    }
+  ]
 };


### PR DESCRIPTION
## Summary
- update Jest config to use a project definition

## Testing
- `npm run hv221:test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685970e8ffb8832796797cbfa9b17403