### PR TITLE
Apply hot-fix PR‑002b to portal simulator

### DIFF
--- a/src/portal-sim.ts
+++ b/src/portal-sim.ts
@@ -1,56 +1,72 @@
-import fs from 'fs';
-
 export interface SimOptions {
   peak: number;      // amps over nominal I0
   duration: number;  // seconds
-  jitter: number;    // ± fraction of peak per tick
-  kappaTarget?: number; // κ_target (default 0.888)
+  jitter?: number;   // ± fractional noise (default 0.04)
+  kappaTarget?: number; // desired κ threshold (default 0.888)
+  tickHz?: number;   // controller tick (default 221)
 }
 
-const TICK_HZ = 221;           // flux-core tick rate
-const DT      = 1 / TICK_HZ;
+// Simple helper to clamp a value between bounds
+const clamp = (v: number, lo: number, hi: number) => Math.min(Math.max(v, lo), hi);
 
-export function κEstimate(iPlus: number, iMinus: number, i0: number): number {
-  return Math.abs(iPlus + iMinus) / (2 * i0);
-}
+/**
+ * Simulates a dual‑coil flux core with a naive PI controller that boosts duty‑cycle
+ * if κ_est drops below target. Returns the minimum κ witnessed across the run so
+ * that tests can assert κ_min ≥ κ_target.
+ */
+export function simulatePortal({
+  peak,
+  duration,
+  jitter = 0.04,
+  kappaTarget = 0.888,
+  tickHz = 221
+}: SimOptions): number {
+  const dt = 1 / tickHz;
+  const totalTicks = Math.floor(duration * tickHz);
+  const I0 = 1; // nominal coil current
 
-export function simulatePortal(opts: SimOptions): number {
-  const { peak, duration, jitter = 0.05, kappaTarget = 0.888 } = opts;
-  const totalTicks = duration * TICK_HZ;
-  let kappaMin = 1;
+  let duty = 0.5; // controller output 0..1
+  const Kp = 0.9;
+  const Ki = 0.3;
+  let integ = 0;
 
-  let integral = 0;
-  let errorPrev = 0;
+  let kappaMin = 10;
 
-  for (let t = 0; t < totalTicks; t++) {
-    // simple sinusoidal coil currents with jitter
-    const Iplus = peak * Math.sin((2 * Math.PI * t) / 13) * (1 + (Math.random() - 0.5) * jitter);
-    const Iminus = peak * Math.sin((2 * Math.PI * t) / 17) * (1 + (Math.random() - 0.5) * jitter);
+  for (let tick = 0; tick < totalTicks; tick++) {
+    const t = tick * dt;
 
-    const kappaEst = Math.abs(Iplus + Iminus) / (2 * peak);
+    // Base dual‑helix currents (red 13‑start, blue 17‑start)
+    const Iplus = peak * Math.sin(13 * 2 * Math.PI * t) * duty;
+    const Iminus = peak * Math.sin(17 * 2 * Math.PI * t) * duty;
+
+    // κ_est per spec
+    const kappaEst = Math.abs(Iplus + Iminus) / (2 * I0);
     kappaMin = Math.min(kappaMin, kappaEst);
 
-    // basic PID dampers (Kp 0.6 Ki 0.1 Kd 0.01)
-    const error = kappaTarget - kappaEst;
-    integral += error;
-    const derivative = error - errorPrev;
-    const control = 0.6 * error + 0.1 * integral + 0.01 * derivative;
+    // Simple PI controller — adjust duty so κ tracks target
+    const err = kappaTarget - kappaEst;
+    integ += err * dt;
+    duty += Kp * err + Ki * integ;
+    duty = clamp(duty, 0, 1);
 
-    // apply control by nudging peak up/down (bounded 0.5–peak)
-    const adj = Math.max(0.5 * peak, Math.min(1.5 * peak, peak + control));
-    // in this stub we don’t actually feed adj back, but could
-    errorPrev = error;
+    // Inject small random jitter into peak
+    peak = peak * (1 + (Math.random() * 2 - 1) * jitter);
   }
 
   return kappaMin;
 }
 
+// CLI entry‑point for manual smoke tests
 if (require.main === module) {
-  const argv = process.argv;
-  const peak      = parseFloat(argv[argv.indexOf('--peak') + 1] || '1.2');
-  const duration  = parseFloat(argv[argv.indexOf('--duration') + 1] || '10');
-  const jitter    = parseFloat(argv[argv.indexOf('--jitter') + 1] || '0.05');
-
-  const κmin = simulatePortal({ peak, duration, jitter });
-  console.log(`κ_min = ${κmin.toFixed(3)}`);
+  const args = process.argv.slice(2);
+  const num = (flag: string, def: number) => {
+    const idx = args.indexOf(flag);
+    return idx === -1 ? def : Number(args[idx + 1]);
+  };
+  const κmin = simulatePortal({
+    peak: num('--peak', 1.2),
+    duration: num('--duration', 10),
+    jitter: num('--jitter', 0.04)
+  });
+  console.log(`κ_min=${κmin.toFixed(3)}`);
 }


### PR DESCRIPTION
## Summary
- simplify portal simulation
- expose κ_min from `simulatePortal`

## Testing
- `npm run hv221:test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68597865e494832781d59b9bcf46d569