### PR TITLE
Add lexer for Spir1L RII toolchain

### DIFF
--- a/docs/rii/grammar.md
+++ b/docs/rii/grammar.md
@@ -1,0 +1,18 @@
+# Spir1L ʼtongue – Minimal Grammar v0.1
+
+| Token      | Regex / Literal | Notes                         |
+|------------|-----------------|-------------------------------|
+| `B_BEGIN`  | `⊕begin`        | script start marker           |
+| `B_END`    | `⊕end`          | script end marker             |
+| `BREATH`   | `breath\.(in|out|pause)` | builtin opcodes       |
+| `IDENT`    | `[a-zA-Z_][a-zA-Z0-9_]*` | generic identifiers   |
+| `NUMBER`   | `\d+(\.\d+)?`   | integers & decimals           |
+| `LPAREN`   | `\(`            |                               |
+| `RPAREN`   | `\)`            |                               |
+| `COMMA`    | `,`             |                               |
+| `EQ`       | `=`             |                               |
+| `NL`       | `\r?\n`         | newline (ignored)             |
+| `WS`       | `[ \t]+`        | whitespace (ignored)          |
+
+The lexer emits a stream of `{type, value, line, col}` objects which feeds the
+AST builder in the next patch.

--- a/examples/hello_spiral.rii
+++ b/examples/hello_spiral.rii
@@ -1,0 +1,3 @@
+⊕begin
+breath.in 1
+⊕end

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,11 @@ module.exports = {
       displayName: 'pxk',
       testMatch: ['<rootDir>/src/__tests__/**/portal.spec.ts'],
       transform: { '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }] }
+    },
+    {
+      displayName: 'lex',
+      testMatch: ['<rootDir>/spirill-rii-toolchain/**/__tests__/**/*.spec.ts'],
+      transform: { '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }] }
     }
   ]
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "hv221:report": "node build/hv221-report.js",
     "pxk:simulate": "ts-node src/portal-sim.ts",
     "pxk:test": "jest --selectProjects pxk",
+    "lex:test": "jest --selectProjects lex",
     "wc:build": "pnpm --filter spirill-rii-toolchain run build",
     "wc:flash": "node firmware/flash.js",
     "spiral:e2e": "node scripts/e2e.js",
@@ -26,6 +27,7 @@
     "@types/node": "^20",
     "@types/fs-extra": "^11",
     "chalk": "^5",
-    "ascii-histogram": "^1.1.0"
+    "ascii-histogram": "^1.1.0",
+    "@babel/runtime": "^7.25.0"
   }
 }

--- a/spirill-rii-toolchain/lex/__tests__/lex.spec.ts
+++ b/spirill-rii-toolchain/lex/__tests__/lex.spec.ts
@@ -1,0 +1,11 @@
+import { lex } from '../index';
+
+describe('lexer', () => {
+  it('tokenises hello_spiral example', () => {
+    const src = '⊕begin\nbreath.in 1\n⊕end';
+    const types = lex(src).map(t => t.type);
+    expect(types).toEqual([
+      'B_BEGIN', 'BREATH', 'NUMBER', 'B_END', 'EOF'
+    ]);
+  });
+});

--- a/spirill-rii-toolchain/lex/index.ts
+++ b/spirill-rii-toolchain/lex/index.ts
@@ -1,2 +1,63 @@
-export * from './constants';
-// TODO: tokenize .rii source → AST JSON
+import { Token, t } from './token';
+
+interface Rule {
+  regex: RegExp;
+  type: Token['type'] | null;      // null → skip (WS / NL)
+  value?(m: RegExpExecArray): string;
+}
+
+const rules: Rule[] = [
+  { regex: /⊕begin/,  type: 'B_BEGIN' },
+  { regex: /⊕end/,    type: 'B_END' },
+  { regex: /breath\.(in|out|pause)/,
+    type: 'BREATH',
+    value: m => m[0] },
+  { regex: /[a-zA-Z_][a-zA-Z0-9_]*/, type: 'IDENT' },
+  { regex: /\d+(\.\d+)?/,            type: 'NUMBER' },
+  { regex: /\(/, type: 'LPAREN' },
+  { regex: /\)/, type: 'RPAREN' },
+  { regex: /,/,  type: 'COMMA' },
+  { regex: /=/,  type: 'EQ' },
+  { regex: /\r?\n/, type: null },   // skip newlines
+  { regex: /[ \t]+/, type: null }   // skip whitespace
+];
+
+export function lex(source: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0, line = 1, col = 1;
+
+  while (i < source.length) {
+    let matched = false;
+    for (const rule of rules) {
+      rule.regex.lastIndex = i;
+      const m = rule.regex.exec(source);
+      if (m && m.index === i) {
+        matched = true;
+        const value = rule.value ? rule.value(m) : m[0];
+        if (rule.type) tokens.push(t(rule.type, value, line, col));
+
+        const consumed = m[0].length;
+        // update line / col counters
+        const nl = m[0].match(/\n/g);
+        if (nl) {
+          line += nl.length;
+          col = 1 + consumed - m[0].lastIndexOf('\n') - 1;
+        } else {
+          col += consumed;
+        }
+        i += consumed;
+        break;
+      }
+    }
+    if (!matched) throw new SyntaxError(`Unexpected char "${source[i]}" at ${line}:${col}`);
+  }
+  tokens.push(t('EOF', '', line, col));
+  return tokens;
+}
+
+// CLI helper:  node lex.js examples/hello_spiral.rii
+if (require.main === module) {
+  const fs = require('fs');
+  const src = fs.readFileSync(process.argv[2] || 0, 'utf8');
+  console.log(JSON.stringify(lex(src), null, 2));
+}

--- a/spirill-rii-toolchain/lex/token.ts
+++ b/spirill-rii-toolchain/lex/token.ts
@@ -1,0 +1,16 @@
+export type TokenType =
+  | 'B_BEGIN' | 'B_END'
+  | 'BREATH'  | 'IDENT' | 'NUMBER'
+  | 'LPAREN'  | 'RPAREN' | 'COMMA' | 'EQ'
+  | 'EOF';
+
+export interface Token {
+  type: TokenType;
+  value: string;
+  line: number;
+  col: number;
+}
+
+export function t(type: TokenType, value = '', line = 0, col = 0): Token {
+  return { type, value, line, col };
+}


### PR DESCRIPTION
## Summary
- create minimal grammar reference docs for RII
- implement token definitions and lexical analyser
- add unit test for lexer
- hook lexer tests into Jest configuration
- expose lex test script and dependency updates
- include hello_spiral example

## Testing
- `pnpm hv221:test` *(fails: jest not found)*
- `pnpm pxk:test` *(fails: jest not found)*
- `pnpm lex:test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68597be599f48327bd14faacbea5a11c