### PR TITLE
Fix regex slice for lexer

### DIFF
--- a/spirill-rii-toolchain/lex/index.ts
+++ b/spirill-rii-toolchain/lex/index.ts
@@ -28,10 +28,10 @@ export function lex(source: string): Token[] {
 
   while (i < source.length) {
     let matched = false;
+    const slice = source.slice(i);           // examine from cursor forward
     for (const rule of rules) {
-      rule.regex.lastIndex = i;
-      const m = rule.regex.exec(source);
-      if (m && m.index === i) {
+      const m = rule.regex.exec(slice);      // match must start at 0
+      if (m && m.index === 0) {
         matched = true;
         const value = rule.value ? rule.value(m) : m[0];
         if (rule.type) tokens.push(t(rule.type, value, line, col));


### PR DESCRIPTION
## Summary
- update lexer to evaluate regexes on a substring instead of relying on lastIndex

## Testing
- `npm run lex:test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685981e6cbcc8327873a00a0f9b28361