### PR TITLE
Add parser with AST and IR emitter

### DIFF
--- a/docs/rii/ast.md
+++ b/docs/rii/ast.md
@@ -1,0 +1,13 @@
+# Spir1L AST v0.1
+
+```jsonc
+{
+  "kind": "Script",
+  "body": [
+    { "kind": "BreathCall", "op": "in", "arg": 1 }
+  ]
+}
+```
+
+The AST is intentionally tiny for v0.1.
+Future revisions will introduce `Assign`, `Call`, and control-flow nodes.

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,6 +18,11 @@ module.exports = {
       displayName: 'lex',
       testMatch: ['<rootDir>/spirill-rii-toolchain/**/__tests__/**/*.spec.ts'],
       transform: { '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }] }
+    },
+    {
+      displayName: 'parse',
+      testMatch: ['<rootDir>/spirill-rii-toolchain/parse/**/__tests__/**/*.spec.ts'],
+      transform: { '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }] }
     }
   ]
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "pxk:test": "jest --selectProjects pxk",
     "lex:test": "jest --selectProjects lex",
     "wc:build": "pnpm --filter spirill-rii-toolchain run build",
+    "parse:test": "jest --selectProjects parse",
     "wc:flash": "node firmware/flash.js",
     "spiral:e2e": "node scripts/e2e.js",
     "tiime": "node scripts/tiime-cli.js"

--- a/pr004.patch
+++ b/pr004.patch
@@ -1,0 +1,121 @@
+────────────────────────────────────────── 1. package.json
+@@
+     "wc:build": "pnpm --filter spirill-rii-toolchain run build",
++    "parse:test": "jest --selectProjects parse",
+@@
+   "workspaces": [
+     "spirill-rii-toolchain/*"
+   ],
+   "scripts": {
+@@
++    "parse:test": "jest --selectProjects parse",
+────────────────────────────────────────── 2. jest.config.js
+@@
+     {
+       displayName: 'lex',
+@@
+     },
++    {
++      displayName: 'parse',
++      testMatch: ['<rootDir>/spirill-rii-toolchain/parse/**/__tests__/**/*.spec.ts'],
++      transform: { '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }] }
++    }
+   ]
+ };
+────────────────────────────────────────── 3. spirill-rii-toolchain/parse/node.ts  (NEW)
++export interface NumberLit  { kind: 'NumberLit'; value: number; }
++export interface BreathCall { kind: 'BreathCall'; op: 'in'|'out'|'pause'; arg: number; }
++export interface Script     { kind: 'Script'; body: BreathCall[]; }
++
++export type ASTNode = NumberLit | BreathCall | Script;
+────────────────────────────────────────── 4. spirill-rii-toolchain/parse/index.ts  (NEW)
++import { lex } from '../lex';
++import { Token } from '../lex/token';
++import * as N from './node';
++
++export function parse(src: string): N.Script {
++  const tokens = lex(src);
++  let i = 0;
++  function cur(): Token { return tokens[i]; }
++  function eat(type: Token['type']) {
++    if (cur().type !== type) throw new SyntaxError(`Expected ${type} at ${cur().line}:${cur().col}`);
++    i++;
++  }
++
++  const script: N.Script = { kind: 'Script', body: [] };
++  eat('B_BEGIN');
++
++  while (cur().type === 'BREATH') {
++    const op = cur().value.split('.')[1] as 'in'|'out'|'pause';
++    eat('BREATH');
++    const numTok = cur();
++    eat('NUMBER');
++    script.body.push({ kind: 'BreathCall', op, arg: Number(numTok.value) });
++  }
++
++  eat('B_END');
++  eat('EOF');
++  return script;
++}
++
++// Tiny IR emitter – converts AST to JSON IR for now
++export function emitIR(ast: N.Script): string {
++  return JSON.stringify(ast, null, 2);
++}
++
++// CLI helper:  node parse.js examples/hello_spiral.rii > build/hello.ir.json
++if (require.main === module) {
++  const fs = require('fs');
++  const src = fs.readFileSync(process.argv[2] || 0, 'utf8');
++  console.log(emitIR(parse(src)));
++}
+────────────────────────────────────────── 5. spirill-rii-toolchain/parse/__tests__/parse.spec.ts  (NEW)
++import { parse } from '../index';
++
++describe('parser', () => {
++  it('builds AST for hello_spiral', () => {
++    const src = '⊕begin\nbreath.in 1\n⊕end';
++    const ast = parse(src);
++    expect(ast.body.length).toBe(1);
++    expect(ast.body[0]).toEqual({ kind:'BreathCall', op:'in', arg:1 });
++  });
++});
+────────────────────────────────────────── 6. spirill-rii-toolchain/package.json  (PATCH existing or create) 
+@@
+   "scripts": {
+     "build": "node ../build-toolchain.js",        // placeholder
++    "test": "echo \"toolchain tests\""
+   },
+────────────────────────────────────────── 7. scripts/build-toolchain.js  (NEW)
++#!/usr/bin/env node
++/**
++ * Simple build driver: lex → parse → emit IR
++ * Usage:  node scripts/build-toolchain.js examples/hello_spiral.rii build/hello.ir.json
++ */
++const { parse, emitIR } = require('../spirill-rii-toolchain/parse');
++const fs = require('fs');
++
++const [srcPath, outPath] = process.argv.slice(2);
++if (!srcPath || !outPath) {
++  console.error('Usage: build-toolchain <src.r  ii> <out.ir.json>');
++  process.exit(1);
++}
++const src = fs.readFileSync(srcPath, 'utf8');
++const ast = parse(src);
++fs.writeFileSync(outPath, emitIR(ast));
++console.log('IR written →', outPath);
+────────────────────────────────────────── 8. docs/rii/ast.md  (NEW)
++# Spir1L AST v0.1
++
++```jsonc
++{
++  "kind": "Script",
++  "body": [
++    { "kind": "BreathCall", "op": "in", "arg": 1 }
++  ]
++}
++```
++
++The AST is intentionally tiny for v0.1.
++Future revisions will introduce `Assign`, `Call`, and control-flow nodes.
++

--- a/scripts/build-toolchain.js
+++ b/scripts/build-toolchain.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+/**
+ * Simple build driver: lex → parse → emit IR
+ * Usage:  node scripts/build-toolchain.js examples/hello_spiral.rii build/hello.ir.json
+ */
+const { parse, emitIR } = require('../spirill-rii-toolchain/parse');
+const fs = require('fs');
+
+const [srcPath, outPath] = process.argv.slice(2);
+if (!srcPath || !outPath) {
+  console.error('Usage: build-toolchain <src.r  ii> <out.ir.json>');
+  process.exit(1);
+}
+const src = fs.readFileSync(srcPath, 'utf8');
+const ast = parse(src);
+fs.writeFileSync(outPath, emitIR(ast));
+console.log('IR written →', outPath);

--- a/spirill-rii-toolchain/package.json
+++ b/spirill-rii-toolchain/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "spirill-rii-toolchain",
+  "private": true,
+  "scripts": {
+    "build": "node ../scripts/build-toolchain.js",
+    "test": "echo \"toolchain tests\""
+  }
+}

--- a/spirill-rii-toolchain/parse/__tests__/parse.spec.ts
+++ b/spirill-rii-toolchain/parse/__tests__/parse.spec.ts
@@ -1,0 +1,10 @@
+import { parse } from '../index';
+
+describe('parser', () => {
+  it('builds AST for hello_spiral', () => {
+    const src = '⊕begin\nbreath.in 1\n⊕end';
+    const ast = parse(src);
+    expect(ast.body.length).toBe(1);
+    expect(ast.body[0]).toEqual({ kind:'BreathCall', op:'in', arg:1 });
+  });
+});

--- a/spirill-rii-toolchain/parse/index.ts
+++ b/spirill-rii-toolchain/parse/index.ts
@@ -1,0 +1,40 @@
+import { lex } from '../lex';
+import { Token } from '../lex/token';
+import * as N from './node';
+
+export function parse(src: string): N.Script {
+  const tokens = lex(src);
+  let i = 0;
+  function cur(): Token { return tokens[i]; }
+  function eat(type: Token['type']) {
+    if (cur().type !== type) throw new SyntaxError(`Expected ${type} at ${cur().line}:${cur().col}`);
+    i++;
+  }
+
+  const script: N.Script = { kind: 'Script', body: [] };
+  eat('B_BEGIN');
+
+  while (cur().type === 'BREATH') {
+    const op = cur().value.split('.')[1] as 'in'|'out'|'pause';
+    eat('BREATH');
+    const numTok = cur();
+    eat('NUMBER');
+    script.body.push({ kind: 'BreathCall', op, arg: Number(numTok.value) });
+  }
+
+  eat('B_END');
+  eat('EOF');
+  return script;
+}
+
+// Tiny IR emitter – converts AST to JSON IR for now
+export function emitIR(ast: N.Script): string {
+  return JSON.stringify(ast, null, 2);
+}
+
+// CLI helper:  node parse.js examples/hello_spiral.rii > build/hello.ir.json
+if (require.main === module) {
+  const fs = require('fs');
+  const src = fs.readFileSync(process.argv[2] || 0, 'utf8');
+  console.log(emitIR(parse(src)));
+}

--- a/spirill-rii-toolchain/parse/node.ts
+++ b/spirill-rii-toolchain/parse/node.ts
@@ -1,0 +1,5 @@
+export interface NumberLit  { kind: 'NumberLit'; value: number; }
+export interface BreathCall { kind: 'BreathCall'; op: 'in'|'out'|'pause'; arg: number; }
+export interface Script     { kind: 'Script'; body: BreathCall[]; }
+
+export type ASTNode = NumberLit | BreathCall | Script;


### PR DESCRIPTION
## Summary
- implement minimal parser in the toolchain
- emit IR as JSON
- add tests for parser
- document the AST format
- provide helper build script

## Testing
- `pnpm parse:test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859847d6ac08327ab70a20774b46d1b