### PR TITLE
Fix globbing in workflow loops

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -28,7 +28,7 @@ jobs:
             <html><head><meta charset="utf-8"><title>Spir1L-OS Portal</title></head><body><h1>Spir1L-OS – Portal Binaries</h1><p>Build: </p></body></html>
           EOF
           shopt -s globstar
-          for f in $(ls **/*.rii); do
+          for f in **/*.rii; do
             base=$(basename "$f" .rii)
             node scripts/build-toolchain.js "$f" ".gate/dist/$base.riic"
           done

--- a/.github/workflows/portal-gate.yml
+++ b/.github/workflows/portal-gate.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           mkdir -p .gate/dist
           shopt -s globstar
-          for f in \$(ls **/*.rii); do
+          for f in **/*.rii; do
             base=\$(basename "\$f" .rii)
             node scripts/build-toolchain.js "\$f" ".gate/dist/\$base.riic"
           done


### PR DESCRIPTION
## Summary
- avoid using `$(ls ...)` in CI scripts
- iterate directly over `**/*.rii` files

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b993143808327896d9fda3ed94111