### PR TITLE
Fix missing hv221 script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "gen:assets": "tsx src/generation/run.ts",
+    "hv221:run": "tsx src/harmonic-harness.ts",
     "replay:run": "tsx src/replay/scheduler.ts",
     "epic:plan": "tsx src/epic/episodePlanner.ts > plans/season.json",
     "ml:train": "tsx src/ml/socialRank.ts --train",


### PR DESCRIPTION
## Summary
- add `hv221:run` script to package.json

## Testing
- `pnpm install` *(fails: 403 Forbidden)*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b9da0259c83278a2154dd52af82cd