### PR TITLE
Add mock reel tooling

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,10 @@
+# === Core ===
+OPENAI_KEY=
+IG_TOKEN=
+TIKTOK_TOKEN=
+YOUTUBE_TOKEN=
+LS_API_KEY=
+LS_STORE_ID=
+
+# === Optional local overrides ===
+# AFrame dev server, etc.

--- a/docs/patch_phi43_edu.md
+++ b/docs/patch_phi43_edu.md
@@ -11,5 +11,5 @@ This patch augments the phi43 bloom spec with a Self-Spir1L curriculum and UI la
 Developers apply with:
 ```bash
 pnpm i
-pnpm -F reel-forge-vr dev
+pnpm -F reel-forge-vr dev -- --mock=mock_reel.mp4
 ```

--- a/docs/phi43_bloom.md
+++ b/docs/phi43_bloom.md
@@ -92,6 +92,7 @@ spforge publish --platform tiktok --dry-run
 
 | Gate | Command | Pass Criterion |
 |------|---------|----------------|
+| G‑0 Local Mock | `python scripts/synth_reel.py --mock` | creates mock_reel.mp4 w/out network calls |
 | G‑1 Compile | `pnpm i && pnpm test` | 100 % unit & type coverage |
 | G‑2 Demo Reel | `python scripts/synth_reel.py --demo` | 1280×720 MP4 ≤15 s, HUD + captions |
 | G‑3 Live Dashboard | `pnpm --filter trust-dashboard dev` | Care/Courage/M’rust live <5 s |
@@ -108,8 +109,12 @@ spforge publish --platform tiktok --dry-run
 OPENAI_KEY=
 HF_TOKEN=
 TIKTOK_TOKEN=
+IG_TOKEN=
+YOUTUBE_TOKEN=
 META_TOKEN=
 STRIPE_KEY=
+LS_API_KEY=
+LS_STORE_ID=
 MQTT_BROKER=
 NETLIFY_AUTH_TOKEN=
 RAILWAY_TOKEN=

--- a/scripts/mock_assets.py
+++ b/scripts/mock_assets.py
@@ -1,0 +1,50 @@
+"""
+Make a 15-sec MP4 with a solid bg + beat-sync text
+No network calls — pure local preview.
+"""
+import subprocess
+import shutil
+from pathlib import Path
+import textwrap
+import sys
+
+FPS = 30
+DURATION = 15  # seconds
+OUT = Path("mock_reel.mp4")
+MSG = textwrap.dedent(
+    """
+    Ma’aT’H’s  |  Lo’Gi¹K  |  p’œ’T’i¹K’s
+    Beat-sync demo — Priivi³ Self-Spir1L
+    """
+).strip()
+
+
+def main() -> None:
+    if shutil.which("ffmpeg") is None:
+        print("ffmpeg not found; cannot create mock video", file=sys.stderr)
+        sys.exit(1)
+    if OUT.exists():
+        OUT.unlink()
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-f",
+            "lavfi",
+            "-i",
+            f"color=c=black:s=720x1280:d={DURATION}:r={FPS}",
+            "-vf",
+            "drawtext=fontfile=/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf:" +
+            f"text='{MSG}':fontcolor=white:fontsize=40:" +
+            "x=(w-text_w)/2:y=(mod(t\\,{1/1.818})*20)",
+            "-pix_fmt",
+            "yuv420p",
+            "-y",
+            str(OUT),
+        ],
+        check=True,
+    )
+    print(f"✅ Mock reel written → {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/synth_reel.py
+++ b/scripts/synth_reel.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""One-shot reel builder."""
+
+import argparse
+import sys
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(description="Synthesize reel")
+    parser.add_argument("--mock", action="store_true", help="Generate local mock reel instead of hitting APIs")
+
+    args = parser.parse_args(argv)
+
+    if args.mock:
+        from mock_assets import main as make_mock
+        make_mock()
+        sys.exit(0)
+
+    # Placeholder for future API-based implementation
+    print("Real reel generation not implemented")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document example environment variables
- add Python helper to generate mock reel locally
- add `--mock` flag to `synth_reel.py`
- mention new quick-start command in edu patch notes
- document `G‑0` mock gate and extra env vars in bloom spec

## Testing
- `python scripts/synth_reel.py --mock`
- `pnpm test` *(fails: fetch from registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685c2e0333e88327ae78d14ee7372004