### PR TITLE
Fix RIIC compile loop quoting

### DIFF
--- a/.github/workflows/portal-gate.yml
+++ b/.github/workflows/portal-gate.yml
@@ -22,8 +22,8 @@ jobs:
           mkdir -p .gate/dist
           shopt -s globstar
           for f in **/*.rii; do
-            base=\$(basename "\$f" .rii)
-            node scripts/build-toolchain.js "\$f" ".gate/dist/\$base.riic"
+            base=$(basename "$f" .rii)
+            node scripts/build-toolchain.js "$f" ".gate/dist/$base.riic"
           done
 
       # ── Size gate (≤256 B each) ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- unescape `$` references in `portal-gate.yml`

## Testing
- `pnpm test` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_685cb072e2c48327896b5b29b69c4b46